### PR TITLE
Arp: Bypass slew limiter when glide is zero.

### DIFF
--- a/src/modules/Arpeggiator.cpp
+++ b/src/modules/Arpeggiator.cpp
@@ -632,9 +632,12 @@ struct Arpeggiator : Module {
 		
 		lights[POLY_LIGHT].setBrightness(boolToLight(polyOutputs));
 		
-		// apply glide
-		float cvOut = slew.process(cv, 1.0f, glideTime, glideTime, args.sampleTime);
-		
+		// apply glide if enabled
+		float cvOut = cv;
+		if (!isNear(glideTime, 0.0f)) {
+			cvOut = slew.process(cv, 1.0f, glideTime, glideTime, args.sampleTime);
+		}
+
 		// output the gate and cv values
 		if (polyOutputs) {
 			maxChannels = std::max(maxChannels, numCVs);


### PR DESCRIPTION
When using Super Arpeggiator with some VSTs via Host, I found that there was an unexpected glide between notes even when the glide setting was disabled for the note or the glide time was set to the minimum value:
![SuperArpGlide](https://user-images.githubusercontent.com/313298/103181337-0a385b00-486e-11eb-82b5-4c725bfafde4.png)

This behavior isn't really noticeable when passing V/Oct directly to an oscillator, but it becomes very prominent when sequencing a voice with discrete pitches (e.g. a piano VST, going through a quantizer).

For my purposes, this was easily fixed by simply bypassing the slew limiter if the `glideTime` value is zero(ish). If the current behavior is intentional, feel free to ignore/close this PR without merging.